### PR TITLE
Support for an analog joystick (aka poti) and a WiiChuck controller.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The game is played on a 1000 unit line, the position of enemies, the player, lav
 
 The game also has 3 regular LEDs for life indicators (the player gets 3 lives which reset each time they level up). The pins for these LEDs are stored in lifeLEDs[] and are updated in the updateLives() function
 
-**//JOYSTICK SETUP** All parameters are commented in the code, you can set it to work in both forward/backward as well as side-to-side mode by changing JOYSTICK_ORIENTATION. Adjust the ATTACK_THRESHOLD if the "Twaning" is overly sensitive and the JOYSTICK_DEADZONE  if the player slowly drifts when there is no input (because it's hard to get the MPU6050 dead level). There are two input methods to choose from (mpu6050 and analog). Uncomment the INPUT_DEVICE_* line you want to use.
+**//JOYSTICK SETUP** All parameters are commented in the code, you can set it to work in both forward/backward as well as side-to-side mode by changing JOYSTICK_ORIENTATION. Adjust the ATTACK_THRESHOLD if the "Twaning" is overly sensitive and the JOYSTICK_DEADZONE  if the player slowly drifts when there is no input (because it's hard to get the MPU6050 dead level). There are three input methods to choose from: the original mpu6050, analog joystick or Wiichuck. There are #defines prepared in the code to choose the input device. Uncomment the INPUT_DEVICE_* line you want to use.
 
 **//WOBBLE ATTACK** Sets the width, duration (ms) of the attack
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The game is played on a 1000 unit line, the position of enemies, the player, lav
 
 The game also has 3 regular LEDs for life indicators (the player gets 3 lives which reset each time they level up). The pins for these LEDs are stored in lifeLEDs[] and are updated in the updateLives() function
 
-**//JOYSTICK SETUP** All parameters are commented in the code, you can set it to work in both forward/backward as well as side-to-side mode by changing JOYSTICK_ORIENTATION. Adjust the ATTACK_THRESHOLD if the "Twaning" is overly sensitive and the JOYSTICK_DEADZONE  if the player slowly drifts when there is no input (because it's hard to get the MPU6050 dead level)
+**//JOYSTICK SETUP** All parameters are commented in the code, you can set it to work in both forward/backward as well as side-to-side mode by changing JOYSTICK_ORIENTATION. Adjust the ATTACK_THRESHOLD if the "Twaning" is overly sensitive and the JOYSTICK_DEADZONE  if the player slowly drifts when there is no input (because it's hard to get the MPU6050 dead level). There are two input methods to choose from (mpu6050 and analog). Uncomment the INPUT_DEVICE_* line you want to use.
 
 **//WOBBLE ATTACK** Sets the width, duration (ms) of the attack
 

--- a/TWANG.ino
+++ b/TWANG.ino
@@ -130,6 +130,7 @@ void setup() {
     
     // Fast LED
     FastLED.addLeds<APA102, DATA_PIN, CLOCK_PIN, LED_COLOR_ORDER>(leds, NUM_LEDS);
+    //FastLED.addLeds<WS2812, DATA_PIN, LED_COLOR_ORDER>(leds, NUM_LEDS);
     FastLED.setBrightness(BRIGHTNESS);
     FastLED.setDither(1);
     

--- a/TWANG.ino
+++ b/TWANG.ino
@@ -4,6 +4,10 @@
 #define INPUT_DEVICE_MPU6050	1	// Use MPU6050 wobbler
 //#define INPUT_DEVICE_ANALOG	1	// Use Analog input on A2 and button on A1
 
+// Uncomment to disable Audio:
+//#define DISABLE_TONEAC 1
+
+
 // Required libs
 #include "FastLED.h"
 #include "I2Cdev.h"
@@ -14,7 +18,10 @@
 #include "RunningMedian.h"
 #endif /* INPUT_DEVICE_MPU6050 */
 
+#if !(defined(DISABLE_TONEAC) && DISABLE_TONEAC)
 #include "toneAC.h"
+#endif
+
 #include "iSin.h"
 
 // Included libs
@@ -25,6 +32,12 @@
 #include "Boss.h"
 #include "Conveyor.h"
 
+
+#if (defined(DISABLE_TONEAC) && DISABLE_TONEAC)
+// dummys for toneAC
+#define toneAC(freq, vol,...)
+#define noToneAC()
+#endif
 
 #if defined(INPUT_DEVICE_MPU6050) && INPUT_DEVICE_MPU6050
 // MPU


### PR DESCRIPTION
This patch contain code for an analog joystick and a WiiChuck controller as input devices. The additional  defines and ifdefs make the code a little less legible. Hope it is still ok. The default should be the same as before.
Thanks for sharing this code!